### PR TITLE
fixed minio.env for minio_root_user and minio_root_password

### DIFF
--- a/templates/minio.env.j2
+++ b/templates/minio.env.j2
@@ -7,11 +7,11 @@ MINIO_ARGS="{{ minio_server_args | join(' ') }}"
 # MinIO cli options.
 MINIO_OPTS="--address {{ minio_server_addr }} {{ minio_server_opts }}"
 
-{% if minio_access_key %}
+{% if minio_root_username %}
 # Access Key of the server.
 MINIO_ROOT_USER="{{ minio_root_username }}"
 {% endif %}
-{% if minio_secret_key %}
+{% if minio_root_password %}
 # Secret key of the server.
 MINIO_ROOT_PASSWORD="{{ minio_root_password }}"
 {% endif %}


### PR DESCRIPTION
about 4 months ago minio introduced a change that deprecated the variables MINIO_ACCESS_KEY and MINIO_SECRET_KEY and replaced them with MINIO_ROOT_USER and MINIO_ROOT_PASSWORD respectively.
fixed minio.env 